### PR TITLE
DOPE-8266 fix sls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,10 @@ _deploy: $(ARTIFACT_PATH) node_modules.zip
 	mkdir -p node_modules
 	unzip -qo -d . node_modules.zip
 	rm -fr .serverless
-	sls deploy -v
+	sls deploy --verbose
 
 _remove:
-	sls remove -v
+	sls remove --verbose
 	rm -fr .serverless
 
 _clean:


### PR DESCRIPTION
Servlers 3 now use `--versbose` instead of `-v` which now means `show version`